### PR TITLE
预览界面直接用图片展示

### DIFF
--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -22,6 +22,7 @@ const getters = {
   cacheModelType: state => state.home.cacheDiePattern.modelType,
   cacheSavedCustomTemplate: state => state.home.cacheDiePattern.savedCustomTemplate,
   sbdCustomTemplate: state => state.home.sbd,
+  bjbCustomTemplate: state => state.home.bjb,
   taobaoNickname: state => state.home.customeTemplate.taobaoNickname,
   theRecipientName: state => state.home.customeTemplate.theRecipientName
 }

--- a/src/store/modules/home.js
+++ b/src/store/modules/home.js
@@ -25,6 +25,7 @@ const home = {
     // 鼠标垫贴膜模具
     sbdDiePattern: null,
     sbd: {},
+    bjb: {},
     // 初始化自定义模板数据
     customeTemplate: {
       // 定制编号
@@ -83,6 +84,9 @@ const home = {
     },
     SET_SBD_CUSTOM: (state, data) => {
       state.sbd = data
+    },
+    SET_BJB_CUSTOM: (state, data) => {
+      state.bjb = data
     },
     SET_BOOKING_TOTAL: (state, total) => {
       state.bookingTotal = total
@@ -275,7 +279,8 @@ const home = {
           if (response[0].status !== 201) reject(new Error('saveCustomTemplates: error'))
           commit('SET_CACHE_CUSTOMNUMBER', state.customeTemplate.customNumber)
           commit('SET_CACHE_MODE_TYPE', state.customeTemplate.modelType.id)
-          commit('SET_SBD_CUSTOM',response[1].data)
+          commit('SET_SBD_CUSTOM', response[1].data)
+          commit('SET_BJB_CUSTOM', response[0].data)
           let data = null
           if (state.customeTemplate.modelType.id === 1) {
             data = response[0].data
@@ -289,18 +294,23 @@ const home = {
         })
       })
     },
-    getCustomTemplateByCustomNumber ({ commit }, customNumber, id, type) {
+    getCustomTemplateByCustomNumber ({ commit }, { customNumber, id, type }) {
       return new Promise((resolve, reject) => {
+        debugger
         queryCustomTemplatesByCustomNumber(customNumber).then(response => {
           if (!response.status === 200) return reject(new Error('getFabricJsonById: error'))
           commit('SET_CACHE_CUSTOMNUMBER', customNumber)
           commit('SET_CACHE_MODE_TYPE', type)
           response.data.forEach(function (item, index, array) {
+            debugger
             if (item.modelType.id === type) {
               commit('SET_CACHE_SAVED_CUSTOME_TEMPLATE', item)
+              commit('SET_CACHE_DATA', item)
             }
             if (item.modelType.id === 2) {
               commit('SET_SBD_CUSTOM', item)
+            } else {
+              commit('SET_BJB_CUSTOM', item)
             }
             resolve()
           })

--- a/src/store/modules/studio.js
+++ b/src/store/modules/studio.js
@@ -104,6 +104,7 @@ const studio = {
      */
     getFabricJsonById ({ commit }, id) {
       return new Promise((resolve, reject) => {
+        debugger
         // 1. 只能用id查询，如果用定制编号查询的话，会出现两条记录一条是笔记本，一条是贴膜的
         Api.getFabricDesignMaterialsByCustomId(id).then(response => {
           if (!response.status === 200) return reject(new Error('getFabricJsonById: error'))

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -168,7 +168,7 @@
                   color="error"
                   @click="goStudio(scope.row)"
                 >
-                  <span style="padding-right: 2px;">继续定制</span> 
+                  <span style="padding-right: 2px;">继续定制</span>
                   <mu-icon size="18" value="computer" v-if="scope.row.modelType.id === 1"></mu-icon>
                   <mu-icon size="18" v-else value="mouse"></mu-icon>
                 </mu-button>

--- a/src/views/components/preview-canvas.vue
+++ b/src/views/components/preview-canvas.vue
@@ -24,13 +24,12 @@
       data-mu-loading-text="正在生成预览效果，请稍等..."
       v-loading="loading"
     >
-      <canvas id="c"></canvas>
+      <img :src="url">
     </div>
   </mu-dialog>
 </template>
 
 <script>
-import fb from '@/utils/fabric'
 import { mapGetters } from 'vuex'
 export default {
   name: 'PreviewCanvas',
@@ -42,6 +41,7 @@ export default {
   },
   data () {
     return {
+      url: '',
       loading: true
     }
   },
@@ -51,16 +51,11 @@ export default {
     ])
   },
   mounted () {
-    const originJSON = this.canvas.toJSON()
-    setTimeout(() => {
-      var preview = fb.initStatic(document.getElementById('c'), {
-        name: 'StaticCanvas',
-        width: this.canvas.width,
-        height: this.canvas.height
-      })
-      preview.loadFromJSON(originJSON)
-      this.loading = false
-    }, 0)
+    this.url = this.canvas.toDataURL({
+      format: 'png',
+      multiplier: 2
+    })
+    this.loading = false
   },
   methods: {
     close () {


### PR DESCRIPTION
1.预览界面直接用图片展示
2。 设计页面中的流程性按钮实现
3。 调整本地上传图片为照片服务器而不是base64
4。 设计完毕后图片保存到服务武器，状态为完成状态

close #15 , close  #19 , close  #14 , close  #7 ,  close  #3 , close  #13 